### PR TITLE
Minor updates

### DIFF
--- a/c_sources/core.pyx
+++ b/c_sources/core.pyx
@@ -1127,12 +1127,14 @@ cdef Node KDTree_create_tree(
     return kdtree.nodes[index]
 
 
-cdef int KDTree_rnn_query(
+cdef void KDTree_rnn_query(
         KDTree *kdtree,
         Particle *par,
         float point[3],
         float dist
         )nogil:
+    if  par.state >= 2:
+        return
 
     global parlist
     cdef float sqdist  = 0
@@ -1144,7 +1146,7 @@ cdef int KDTree_rnn_query(
     if kdtree.root_node[0].index != kdtree.nodes[0].index:
         par.neighbours[0] = -1
         par.neighboursnum = 0
-        return -1
+        return
     else:
         sqdist = dist * dist
         KDTree_rnn_search(

--- a/operators.py
+++ b/operators.py
@@ -334,9 +334,16 @@ class MolSimulateModal(bpy.types.Operator):
                         psys.particles.foreach_set('velocity', mol_importdata[1][i])
                         i += 1
 
-            if framesubstep == int(framesubstep):
+            scene.mol_newlink = 0
+            scene.mol_deadlink = 0
 
-                mol_substep *= 2.5
+            scene.mol_newlink += mol_importdata[2]
+            scene.mol_deadlink += mol_importdata[3]
+            scene.mol_totallink = mol_importdata[4]
+            scene.mol_totaldeadlink = mol_importdata[5]
+            scene.frame_set(frame=frame_current + 1)
+
+            if framesubstep == int(framesubstep):
                 print("    frame " + str(int(framesubstep) + 1) + ":")
                 print("      links created:", scene.mol_newlink)
                 if scene.mol_totallink:
@@ -347,7 +354,7 @@ class MolSimulateModal(bpy.types.Operator):
                 blendertime = etime3 - stime3
                 print("      Pack             : " + str(round(packtime * (mol_substep + 1), 3)) + " sec")
                 print("      Molecular        : " + str(round(moltime * (mol_substep + 1), 3)) + " sec")
-                print("      Blender          : " + str(round((blendertime + packtime) * (mol_substep + 1), 3)) + " sec")
+                print("      Blender          : " + str(round(blendertime * (mol_substep + 1), 3)) + " sec")
                 print("      Total Frame      : " + str(round((blendertime + packtime + moltime) * (mol_substep + 1), 3)) + " sec")
 
                 remain = (blendertime + packtime + moltime) * (mol_substep + 1) * (float(scene.mol_old_endframe) - (framesubstep + 1.0))
@@ -355,14 +362,6 @@ class MolSimulateModal(bpy.types.Operator):
                 days = int(strftime('%d', gmtime(remain))) - 1
                 scene.mol_timeremain = strftime(str(days) + ' days %H hours %M mins %S secs', gmtime(remain))
                 print("      Remaining estimated:", scene.mol_timeremain)
-            scene.mol_newlink = 0
-            scene.mol_deadlink = 0
-
-            scene.mol_newlink += mol_importdata[2]
-            scene.mol_deadlink += mol_importdata[3]
-            scene.mol_totallink = mol_importdata[4]
-            scene.mol_totaldeadlink = mol_importdata[5]
-            scene.frame_set(frame=frame_current + 1)
 
         return {'PASS_THROUGH'}
 


### PR DESCRIPTION
- Skip rnn_query if the particle does not exist
I think we can safely skip rnn_query for particles whose state is not "ALIVE". 

- Move printing timing info to the end of the function
The heaviest blender operation is scene.frame_set when there are many collision objects in the scene. So, it is better to measure blender time after scene.frame_set  is finished.     