### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Build with Cython
         id: build
-        run: echo "::set-output name=version::$(python pack_molecular.py)"
+        run: echo "version=$(python pack_molecular.py)" >> $GITHUB_OUTPUT
       - name: Upload windows zip
         uses: actions/upload-artifact@v2
         with:
@@ -62,7 +62,7 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Build with Cython
         id: build
-        run: echo "::set-output name=version::$(python pack_molecular.py)"
+        run: echo "version=$(python pack_molecular.py)" >> $GITHUB_OUTPUT
       - name: Upload linux zip
         uses: actions/upload-artifact@v2
         with:
@@ -93,7 +93,7 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Build with Cython
         id: build
-        run: echo "::set-output name=version::$(python pack_molecular.py)"
+        run: echo "version=$(python pack_molecular.py)" >> $GITHUB_OUTPUT
       - name: Upload mac zip
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


