### PR TITLE
Hide Dead and Unborn particles on Geo instances

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -528,6 +528,8 @@ class MolToolsConvertGeo(bpy.types.Operator):
         bpy.ops.object.editmode_toggle()
         bpy.ops.object.modifier_add(type='PARTICLE_INSTANCE')
         bpy.context.object.modifiers["ParticleInstance"].object = obj
+        bpy.context.object.modifiers["ParticleInstance"].show_dead = False
+        bpy.context.object.modifiers["ParticleInstance"].show_unborn = False
 
         bpy.ops.node.new_geometry_nodes_modifier()
 


### PR DESCRIPTION
When converting particle systems to Geometry Nodes, the `Show Dead` and `Show Unborn` options in the `ParticleInstance` modifier are enabled by default:

![image](https://github.com/u3dreal/molecular-plus/assets/75134774/bab40a27-606e-4ea7-ba8c-88efd3edbd07)

This makes the Geo instance behave differently visually than the particle system itself:

https://github.com/u3dreal/molecular-plus/assets/75134774/c8791d20-19c5-4373-a6f2-dfe1e2f7ea2a

This PR fixes the issue by turning off visibility of Dead and Unborn particles in the GN instance, which is specially useful on projects that use multiple particle systems triggered at different frames.