### PR TITLE
Remove spaces from the version label in the panel UI

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -4,7 +4,7 @@ from . import bl_info
 
 class MS_PT_MolecularHelperPanel(bpy.types.Panel):
     """Creates a Panel in the Tool properties window"""
-    bl_label = "Molecular+     v"  + str(bl_info['version']).replace('(','').replace(')','').replace(',','.')
+    bl_label = "Molecular+     v"  + str(bl_info['version']).replace('(','').replace(')','').replace(', ','.')
     bl_idname = "OBJECT_PT_molecular_helper"
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'


### PR DESCRIPTION
Before:
![image](https://github.com/u3dreal/molecular-plus/assets/75134774/7b64e441-18e1-4ca4-83a5-d23346e26e82)

After:
![image](https://github.com/u3dreal/molecular-plus/assets/75134774/593106ad-d16c-4d06-ab85-516ace2db693)

Though, a better approach would be to use % formatting like so:
```python
bl_label = "Molecular+     v%d.%d.%d" % (bl_info['version'][0], bl_info['version'][1], bl_info['version'][2])
```

Please let me know if you want me to do that instead.