### PR TITLE
Blender 4.2 and Python 3.12 Support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,7 +252,7 @@ jobs:
           path: ./molecular-plus_${{ env.VERSION }}_311_macos.zip
   
   # MacOS, Blender 4.2, Python 3.12
-  # build_macos41:
+  # build_macos42:
   #   runs-on: macos-13
   #   outputs:
   #     VERSION: ${{ steps.build.outputs.VERSION }}
@@ -287,13 +287,13 @@ jobs:
     needs:
       - build_windows
       - build_windows41
-      - build_windows42
+      #- build_windows42
       - build_linux
       - build_linux41
       - build_linux42
       - build_macos
       - build_macos41
-      - build_macos42
+      #- build_macos42
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,37 @@ jobs:
         with:
           name: molecular-plus_${{ env.VERSION }}_311_win
           path: ./molecular-plus_${{ env.VERSION }}_311_win.zip
+  
+  # Windows, Blender 4.2, Python 3.12
+  build_windows42:
+    runs-on: windows-latest
+    outputs:
+      VERSION: ${{ steps.build.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.12.4
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.12.4
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest cython
+      - name: Lint with flake8
+        run: |
+          flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Build with Cython
+        id: build
+        run: |
+          $version = python pack_molecular.py
+          echo "VERSION=${version}" >> $env:GITHUB_ENV
+          echo "::set-output name=VERSION::${version}"
+      - name: Upload windows zip
+        uses: actions/upload-artifact@v3
+        with:
+          name: molecular-plus_${{ env.VERSION }}_312_win
+          path: ./molecular-plus_${{ env.VERSION }}_312_win.zip
 
   build_linux:
     runs-on: ubuntu-22.04
@@ -128,6 +159,37 @@ jobs:
         with:
           name: molecular-plus_${{ env.VERSION }}_311_linux
           path: ./molecular-plus_${{ env.VERSION }}_311_linux.zip
+  
+  # Linux, Blender 4.2, Python 3.12
+  build_linux42:
+    runs-on: ubuntu-22.04
+    outputs:
+      VERSION: ${{ steps.build.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.12.4
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.12.4
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest cython
+      - name: Lint with flake8
+        run: |
+          flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Build with Cython
+        id: build
+        run: |
+          version=$(python pack_molecular.py)
+          echo "VERSION=${version}" >> $GITHUB_ENV
+          echo "::set-output name=VERSION::${version}"
+      - name: Upload linux zip
+        uses: actions/upload-artifact@v3
+        with:
+          name: molecular-plus_${{ env.VERSION }}_312_linux
+          path: ./molecular-plus_${{ env.VERSION }}_312_linux.zip
 
   build_macos:
     runs-on: macos-13
@@ -188,16 +250,50 @@ jobs:
         with:
           name: molecular-plus_${{ env.VERSION }}_311_macos
           path: ./molecular-plus_${{ env.VERSION }}_311_macos.zip
+  
+  # MacOS, Blender 4.2, Python 3.12
+  build_macos41:
+    runs-on: macos-13
+    outputs:
+      VERSION: ${{ steps.build.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.12.4
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.12.4
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest cython
+      - name: Lint with flake8
+        run: |
+          flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Build with Cython
+        id: build
+        run: |
+          version=$(python pack_molecular.py)
+          echo "VERSION=${version}" >> $GITHUB_ENV
+          echo "::set-output name=VERSION::${version}"
+      - name: Upload mac zip
+        uses: actions/upload-artifact@v3
+        with:
+          name: molecular-plus_${{ env.VERSION }}_312_macos
+          path: ./molecular-plus_${{ env.VERSION }}_312_macos.zip
 
   release:
     runs-on: ubuntu-latest
     needs:
       - build_windows
       - build_windows41
+      - build_windows42
       - build_linux
       - build_linux41
+      - build_linux42
       - build_macos
       - build_macos41
+      - build_macos42
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,6 +322,11 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: molecular-plus_${{ needs.build_linux41.outputs.VERSION }}_311_linux
+      
+      - name: Download artifacts for Linux 312
+        uses: actions/download-artifact@v3
+        with:
+          name: molecular-plus_${{ needs.build_linux41.outputs.VERSION }}_312_linux
 
       - name: Download artifacts for macOS 310
         uses: actions/download-artifact@v3
@@ -341,6 +346,7 @@ jobs:
             molecular-plus_${{ needs.build_windows41.outputs.VERSION }}_311_win.zip \
             molecular-plus_${{ needs.build_linux.outputs.VERSION }}_310_linux.zip \
             molecular-plus_${{ needs.build_linux41.outputs.VERSION }}_311_linux.zip \
+            molecular-plus_${{ needs.build_linux42.outputs.VERSION }}_312_linux.zip \
             molecular-plus_${{ needs.build_macos.outputs.VERSION }}_310_macos.zip \
             molecular-plus_${{ needs.build_macos41.outputs.VERSION }}_311_macos.zip \
             --title "Release $tag" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,35 +70,35 @@ jobs:
           path: ./molecular-plus_${{ env.VERSION }}_311_win.zip
   
   # Windows, Blender 4.2, Python 3.12
-  build_windows42:
-    runs-on: windows-latest
-    outputs:
-      VERSION: ${{ steps.build.outputs.VERSION }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.12.4
-        uses: actions/setup-python@v3
-        with:
-          python-version: 3.12.4
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install flake8 pytest cython
-      - name: Lint with flake8
-        run: |
-          flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Build with Cython
-        id: build
-        run: |
-          $version = python pack_molecular.py
-          echo "VERSION=${version}" >> $env:GITHUB_ENV
-          echo "::set-output name=VERSION::${version}"
-      - name: Upload windows zip
-        uses: actions/upload-artifact@v3
-        with:
-          name: molecular-plus_${{ env.VERSION }}_312_win
-          path: ./molecular-plus_${{ env.VERSION }}_312_win.zip
+  # build_windows42:
+  #   runs-on: windows-latest
+  #   outputs:
+  #     VERSION: ${{ steps.build.outputs.VERSION }}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Python 3.12.4
+  #       uses: actions/setup-python@v3
+  #       with:
+  #         python-version: 3.12.4
+  #     - name: Install dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install flake8 pytest cython
+  #     - name: Lint with flake8
+  #       run: |
+  #         flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
+  #         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  #     - name: Build with Cython
+  #       id: build
+  #       run: |
+  #         $version = python pack_molecular.py
+  #         echo "VERSION=${version}" >> $env:GITHUB_ENV
+  #         echo "::set-output name=VERSION::${version}"
+  #     - name: Upload windows zip
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: molecular-plus_${{ env.VERSION }}_312_win
+  #         path: ./molecular-plus_${{ env.VERSION }}_312_win.zip
 
   build_linux:
     runs-on: ubuntu-22.04
@@ -252,35 +252,35 @@ jobs:
           path: ./molecular-plus_${{ env.VERSION }}_311_macos.zip
   
   # MacOS, Blender 4.2, Python 3.12
-  build_macos41:
-    runs-on: macos-13
-    outputs:
-      VERSION: ${{ steps.build.outputs.VERSION }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.12.4
-        uses: actions/setup-python@v3
-        with:
-          python-version: 3.12.4
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install flake8 pytest cython
-      - name: Lint with flake8
-        run: |
-          flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Build with Cython
-        id: build
-        run: |
-          version=$(python pack_molecular.py)
-          echo "VERSION=${version}" >> $GITHUB_ENV
-          echo "::set-output name=VERSION::${version}"
-      - name: Upload mac zip
-        uses: actions/upload-artifact@v3
-        with:
-          name: molecular-plus_${{ env.VERSION }}_312_macos
-          path: ./molecular-plus_${{ env.VERSION }}_312_macos.zip
+  # build_macos41:
+  #   runs-on: macos-13
+  #   outputs:
+  #     VERSION: ${{ steps.build.outputs.VERSION }}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Python 3.12.4
+  #       uses: actions/setup-python@v3
+  #       with:
+  #         python-version: 3.12.4
+  #     - name: Install dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install flake8 pytest cython
+  #     - name: Lint with flake8
+  #       run: |
+  #         flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
+  #         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  #     - name: Build with Cython
+  #       id: build
+  #       run: |
+  #         version=$(python pack_molecular.py)
+  #         echo "VERSION=${version}" >> $GITHUB_ENV
+  #         echo "::set-output name=VERSION::${version}"
+  #     - name: Upload mac zip
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: molecular-plus_${{ env.VERSION }}_312_macos
+  #         path: ./molecular-plus_${{ env.VERSION }}_312_macos.zip
 
   release:
     runs-on: ubuntu-latest

--- a/pack_molecular.py
+++ b/pack_molecular.py
@@ -22,14 +22,15 @@ if is_linux:
 elif is_windows:
     name = 'win'
 
-mkdir(".//molecularplus" + name)
+temp_folder = "molecularplus" + name
+mkdir(temp_folder)
 
 pyfiles = (
     "__init__.py", "creators.py", "descriptions.py", "names.py", "operators.py", "properties.py",
     "simulate.py", "ui.py", "utils.py", "addon_prefrences.py")
 
 for file in pyfiles:
-    shutil.copy(file, ".//molecularplus//" + file)
+    shutil.copy(file, f".//{temp_folder}//{file}")
 
 from molecularplus import bl_info
 
@@ -44,21 +45,21 @@ with Popen([sys.executable, "setup.py", "build_ext", "--inplace"], stdout=PIPE) 
     proc.stdout.read()
 
     if is_linux:  # TODO, test
-        shutil.move("core.cpython-{}-x86_64-linux-gnu.so".format(v),
-                    "..//molecularplus//core.cpython-{}-x86_64-linux-gnu.so".format(v))
+        shutil.move(f"core.cpython-{v}-x86_64-linux-gnu.so",
+                    f"..//{temp_folder}//core.cpython-{v}-x86_64-linux-gnu.so")
     elif is_windows:
-        shutil.move("core.cp{}-win_amd64.pyd".format(v), "..//molecularplus//core.cp{}-win_amd64.pyd".format(v))
+        shutil.move(f"core.cp{v}-win_amd64.pyd", f"..//{temp_folder}//core.cp{v}-win_amd64.pyd")
     else:
-        shutil.move("core.cpython-{}-darwin.so".format(v), "..//molecularplus//core.cpython-{}-darwin.so".format(v))
+        shutil.move(f"core.cpython-{v}-darwin.so", f"..//{temp_folder}//core.cpython-{v}-darwin.so")
 
     chdir("..")
 
     molfiles = (
     "__init__.py", "creators.py", "descriptions.py", "names.py", "operators.py", "properties.py", "addon_prefrences.py",
-    "simulate.py", "ui.py", "utils.py", 'core.cpython-{}-darwin.so'.format(v), 'core.cp{}-win_amd64.pyd'.format(v), 'core.cpython-{}-x86_64-linux-gnu.so'.format(v))
+    "simulate.py", "ui.py", "utils.py", f'core.cpython-{v}-darwin.so', f'core.cp{v}-win_amd64.pyd', f'core.cpython-{v}-x86_64-linux-gnu.so')
 
-    with ZipFile('molecular-plus_{}_'.format(version) + '{}_'.format(v) + name + '.zip', 'w') as z:
-        for root, _, files in walk('molecularplus'):
+    with ZipFile(f'molecular-plus_{version}_' + f'{v}_{name}.zip', 'w') as z:
+        for root, _, files in walk(temp_folder):
             for file in files:
                 if file not in molfiles:
                     continue
@@ -66,7 +67,7 @@ with Popen([sys.executable, "setup.py", "build_ext", "--inplace"], stdout=PIPE) 
 
     # cleanup
 
-    shutil.rmtree(".//molecularplus")
+    shutil.rmtree(f".//{temp_folder}")
 
     # chdir(getcwd() + "//molecularplus")
     # try:

--- a/pack_molecular.py
+++ b/pack_molecular.py
@@ -32,7 +32,12 @@ pyfiles = (
 for file in pyfiles:
     shutil.copy(file, f".//{temp_folder}//{file}")
 
-from molecularplus import bl_info
+if is_linux:
+    from molecularpluslinux import bl_info
+elif is_windows:
+    from molecularpluswin import bl_info
+else:
+    from molecularplus import bl_info
 
 chdir(getcwd() + "//c_sources")
 


### PR DESCRIPTION
**.github/workflows/release.yml**
* Added CI support for Python 3.12 and Blender 4.2

**pack_molecular.py**
* Made temp folder name consistent by having OS name in it